### PR TITLE
feat: silence dapp logs

### DIFF
--- a/typescript/Dockerfile
+++ b/typescript/Dockerfile
@@ -37,6 +37,7 @@ WORKDIR /opt/cartesi/dapp
 COPY --from=build-stage /opt/cartesi/dapp/dist .
 
 ENV ROLLUP_HTTP_SERVER_URL="http://127.0.0.1:5004"
+COPY ./rollup-init /opt/cartesi/bin/rollup-init
 
 ENTRYPOINT ["rollup-init"]
 CMD ["node", "index.js"]

--- a/typescript/rollup-init
+++ b/typescript/rollup-init
@@ -1,0 +1,23 @@
+#!/bin/busybox sh
+
+# Copyright Cartesi and individual authors (see AUTHORS)
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+busybox sh -c "RUST_LOG=off /opt/cartesi/bin/rollup-http-server $*"
+MESSAGE="rollup-http-server exited with $? status"
+echo "$MESSAGE"
+echo "{\"payload\": \"$MESSAGE\"}" | rollup exception


### PR DESCRIPTION
With this change, the logs from the rollup-http-server are silenced from the logs.

I don't think this is the best approach, but it's just a PoC for what would be the ideal scenario to have as the log output for `sunodo run` and for the deployment infrastructure.