### PR TITLE
fix: curl 1.13 removed due to security reasons, upgrading to 1.14

### DIFF
--- a/cpp-low-level/Dockerfile
+++ b/cpp-low-level/Dockerfile
@@ -20,7 +20,7 @@ LABEL io.cartesi.rollups.ram_size=128Mi
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
 apt-get update
-apt-get install -y --no-install-recommends busybox-static=1:1.30.1-7ubuntu3 ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.13
+apt-get install -y --no-install-recommends busybox-static=1:1.30.1-7ubuntu3 ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.14
 curl -fsSL https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.tar.gz \
   | tar -C / --overwrite -xvzf -
 rm -rf /var/lib/apt/lists/*

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -19,7 +19,7 @@ LABEL io.cartesi.rollups.ram_size=128Mi
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
 apt-get update
-apt-get install -y --no-install-recommends busybox-static=1:1.30.1-7ubuntu3 ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.13
+apt-get install -y --no-install-recommends busybox-static=1:1.30.1-7ubuntu3 ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.14
 cd /tmp
 curl -fsSL https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.tar.gz \
   | tar -C / --overwrite -xvzf -

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -36,7 +36,7 @@ LABEL io.cartesi.rollups.ram_size=128Mi
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
 apt-get update
-apt-get install -y --no-install-recommends busybox-static=1:1.30.1-7ubuntu3 ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.13
+apt-get install -y --no-install-recommends busybox-static=1:1.30.1-7ubuntu3 ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.14
 curl -fsSL https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.tar.gz \
   | tar -C / --overwrite -xvzf -
 rm -rf /var/lib/apt/lists/*

--- a/javascript/Dockerfile
+++ b/javascript/Dockerfile
@@ -25,7 +25,7 @@ LABEL io.cartesi.rollups.ram_size=128Mi
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
 apt-get update
-apt-get install -y --no-install-recommends busybox-static=1:1.30.1-7ubuntu3 ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.13
+apt-get install -y --no-install-recommends busybox-static=1:1.30.1-7ubuntu3 ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.14
 curl -fsSL https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.tar.gz \
   | tar -C / --overwrite -xvzf -
 rm -rf /var/lib/apt/lists/*

--- a/lua/Dockerfile
+++ b/lua/Dockerfile
@@ -21,7 +21,7 @@ apt-get update
 apt-get install -y --no-install-recommends \
   busybox-static=1:1.30.1-7ubuntu3 \
   ca-certificates=20230311ubuntu0.22.04.1 \
-  curl=7.81.0-1ubuntu1.13 \
+  curl=7.81.0-1ubuntu1.14 \
   liblua5.4-dev=5.4.4-1 \
   lua5.4=5.4.4-1
 curl -fsSL https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.tar.gz \

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -7,7 +7,7 @@ LABEL io.cartesi.rollups.ram_size=128Mi
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
 apt-get update
-apt-get install -y --no-install-recommends busybox-static=1:1.30.1-7ubuntu3 ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.13
+apt-get install -y --no-install-recommends busybox-static=1:1.30.1-7ubuntu3 ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.14
 curl -fsSL https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.tar.gz \
   | tar -C / --overwrite -xvzf -
 rm -rf /var/lib/apt/lists/*

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -26,7 +26,7 @@ LABEL io.cartesi.rollups.ram_size=128Mi
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
 apt-get update
-apt-get install -y --no-install-recommends busybox-static=1:1.30.1-7ubuntu3 ruby="1:3.0~exp1" ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.13
+apt-get install -y --no-install-recommends busybox-static=1:1.30.1-7ubuntu3 ruby="1:3.0~exp1" ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.14
 curl -fsSL https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.tar.gz \
   | tar -C / --overwrite -xvzf -
 rm -rf /var/lib/apt/lists/*

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -53,7 +53,7 @@ apt-get update
 apt-get install -y --no-install-recommends \
     busybox-static=1:1.30.1-7ubuntu3 \
     ca-certificates=20230311ubuntu0.22.04.1 \
-    curl=7.81.0-1ubuntu1.13
+    curl=7.81.0-1ubuntu1.14
 curl -fsSL https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.tar.gz \
   | tar -C / --overwrite -xvzf -
 rm -rf /var/lib/apt/lists/*

--- a/typescript/Dockerfile
+++ b/typescript/Dockerfile
@@ -25,7 +25,7 @@ LABEL io.cartesi.rollups.ram_size=128Mi
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
 apt-get update
-apt-get install -y --no-install-recommends busybox-static=1:1.30.1-7ubuntu3 ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.13
+apt-get install -y --no-install-recommends busybox-static=1:1.30.1-7ubuntu3 ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.14
 curl -fsSL https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.tar.gz \
   | tar -C / --overwrite -xvzf -
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
curl 1.13 removed (security)

```
curl (7.81.0-1ubuntu1.13) jammy-security; urgency=medium

  * SECURITY REGRESSION: broken ssl cert wildcard handling (LP: #2028170)
    - debian/patches/CVE-2023-28321.patch: fix missing line in backport.

 -- Marc Deslauriers <marc.deslauriers@ubuntu.com>  Wed, 19 Jul 2023 12:23:36 -0400
```

source: http://changelogs.ubuntu.com/changelogs/pool/main/c/curl/curl_7.81.0-1ubuntu1.14/changelog
