### PR TITLE
Feat/docker enhancements

### DIFF
--- a/cpp-low-level/Dockerfile
+++ b/cpp-low-level/Dockerfile
@@ -2,6 +2,7 @@
 FROM --platform=linux/riscv64 riscv64/ubuntu:22.04 as builder
 
 RUN <<EOF
+set -e
 apt-get update
 apt-get install -y --no-install-recommends autoconf automake ca-certificates curl build-essential libtool wget 
 rm -rf /var/lib/apt/lists/*
@@ -19,6 +20,7 @@ LABEL io.cartesi.rollups.ram_size=128Mi
 
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
+set -e
 apt-get update
 apt-get install -y --no-install-recommends busybox-static=1:1.30.1-7ubuntu3 ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.15
 curl -fsSL https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.tar.gz \

--- a/cpp-low-level/Dockerfile
+++ b/cpp-low-level/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker.io/docker/dockerfile:1.4
+# syntax=docker.io/docker/dockerfile:1
 FROM --platform=linux/riscv64 riscv64/ubuntu:22.04 as builder
 
 RUN <<EOF

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -2,6 +2,7 @@
 FROM --platform=linux/riscv64 riscv64/ubuntu:22.04 as builder
 
 RUN <<EOF
+set -e
 apt-get update
 apt-get install -y --no-install-recommends autoconf automake ca-certificates curl build-essential libtool wget
 rm -rf /var/lib/apt/lists/*
@@ -18,6 +19,7 @@ LABEL io.cartesi.rollups.ram_size=128Mi
 
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
+set -e
 apt-get update
 apt-get install -y --no-install-recommends busybox-static=1:1.30.1-7ubuntu3 ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.15
 cd /tmp

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker.io/docker/dockerfile:1.4
+# syntax=docker.io/docker/dockerfile:1
 FROM --platform=linux/riscv64 riscv64/ubuntu:22.04 as builder
 
 RUN <<EOF

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker.io/docker/dockerfile:1.4
+# syntax=docker.io/docker/dockerfile:1
 FROM ubuntu:22.04 as build-stage
 
 RUN <<EOF

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -2,6 +2,7 @@
 FROM ubuntu:22.04 as build-stage
 
 RUN <<EOF
+set -e
 apt update
 apt install -y --no-install-recommends \
     build-essential=12.9ubuntu3 \
@@ -15,7 +16,7 @@ ARG GOVERSION=1.20.5
 WORKDIR /opt/build
 
 RUN wget https://go.dev/dl/go${GOVERSION}.linux-$(dpkg --print-architecture).tar.gz && \
-    tar -C /usr/local -xzf go${GOVERSION}.linux-$(dpkg --print-architecture).tar.gz
+  tar -C /usr/local -xzf go${GOVERSION}.linux-$(dpkg --print-architecture).tar.gz
 
 ENV GOOS=linux
 ENV GOARCH=riscv64
@@ -35,6 +36,7 @@ LABEL io.cartesi.rollups.ram_size=128Mi
 
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
+set -e
 apt-get update
 apt-get install -y --no-install-recommends busybox-static=1:1.30.1-7ubuntu3 ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.15
 curl -fsSL https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.tar.gz \

--- a/javascript/Dockerfile
+++ b/javascript/Dockerfile
@@ -24,6 +24,7 @@ LABEL io.cartesi.rollups.ram_size=128Mi
 
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
+set -e
 apt-get update
 apt-get install -y --no-install-recommends busybox-static=1:1.30.1-7ubuntu3 ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.15
 curl -fsSL https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.tar.gz \

--- a/javascript/Dockerfile
+++ b/javascript/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker.io/docker/dockerfile:1.4
+# syntax=docker.io/docker/dockerfile:1
 
 # build stage: includes resources necessary for installing dependencies
 

--- a/lua/Dockerfile
+++ b/lua/Dockerfile
@@ -2,6 +2,7 @@
 FROM --platform=linux/riscv64 riscv64/ubuntu:22.04 as builder
 
 RUN <<EOF
+set -e
 apt-get update
 apt-get install -y --no-install-recommends build-essential=12.9ubuntu3 lua5.4=5.4.4-1 liblua5.4-dev=5.4.4-1 luarocks=3.8.0+dfsg1-1
 rm -rf /var/lib/apt/lists/*
@@ -17,6 +18,7 @@ LABEL io.cartesi.rollups.ram_size=128Mi
 
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
+set -e
 apt-get update
 apt-get install -y --no-install-recommends \
   busybox-static=1:1.30.1-7ubuntu3 \

--- a/lua/Dockerfile
+++ b/lua/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker.io/docker/dockerfile:1.4
+# syntax=docker.io/docker/dockerfile:1
 FROM --platform=linux/riscv64 riscv64/ubuntu:22.04 as builder
 
 RUN <<EOF

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -6,6 +6,7 @@ LABEL io.cartesi.rollups.ram_size=128Mi
 
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
+set -e
 apt-get update
 apt-get install -y --no-install-recommends busybox-static=1:1.30.1-7ubuntu3 ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.15
 curl -fsSL https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.tar.gz \
@@ -19,6 +20,7 @@ WORKDIR /opt/cartesi/dapp
 COPY ./requirements.txt .
 
 RUN <<EOF
+set -e
 pip install -r requirements.txt --no-cache
 find /usr/local/lib -type d -name __pycache__ -exec rm -r {} +
 EOF

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker.io/docker/dockerfile:1.4
+# syntax=docker.io/docker/dockerfile:1
 FROM --platform=linux/riscv64 cartesi/python:3.10-slim-jammy
 
 LABEL io.sunodo.sdk_version=0.2.0

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker.io/docker/dockerfile:1.4
+# syntax=docker.io/docker/dockerfile:1
 FROM --platform=linux/riscv64 riscv64/ubuntu:22.04 as base
 
 RUN apt-get update

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update
 FROM base as builder
 
 RUN <<EOF
+set -e
 apt-get install -y ruby="1:3.0~exp1" ruby-dev="1:3.0~exp1" build-essential=12.9ubuntu3
 rm -rf /var/apt/lists/*
 gem install bundler --no-document
@@ -14,6 +15,7 @@ EOF
 COPY Gemfile Gemfile.lock ./
 
 RUN <<EOF
+set -e
 bundle config set --without 'development test'
 bundle install --jobs=3 --retry=3
 EOF
@@ -25,6 +27,7 @@ LABEL io.cartesi.rollups.ram_size=128Mi
 
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
+set -e
 apt-get update
 apt-get install -y --no-install-recommends busybox-static=1:1.30.1-7ubuntu3 ruby="1:3.0~exp1" ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.15
 curl -fsSL https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.tar.gz \

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker.io/docker/dockerfile:1.4
+# syntax=docker.io/docker/dockerfile:1
 FROM ubuntu:22.04 as builder
 
 ENV RUSTUP_HOME=/usr/local/rustup \

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -7,6 +7,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     RUST_VERSION=1.72.0
 
 RUN <<EOF
+set -e
 apt update
 apt install -y --no-install-recommends \
     build-essential=12.9ubuntu3 \
@@ -49,6 +50,7 @@ LABEL io.cartesi.rollups.ram_size=128Mi
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 
 RUN <<EOF
+set -e
 apt-get update
 apt-get install -y --no-install-recommends \
     busybox-static=1:1.30.1-7ubuntu3 \

--- a/typescript/Dockerfile
+++ b/typescript/Dockerfile
@@ -24,6 +24,7 @@ LABEL io.cartesi.rollups.ram_size=128Mi
 
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
+set -e
 apt-get update
 apt-get install -y --no-install-recommends busybox-static=1:1.30.1-7ubuntu3 ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.15
 curl -fsSL https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.tar.gz \

--- a/typescript/Dockerfile
+++ b/typescript/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker.io/docker/dockerfile:1.4
+# syntax=docker.io/docker/dockerfile:1
 
 # build stage: includes resources necessary for installing dependencies
 


### PR DESCRIPTION
This PR will:

Lock to major builder version `1` to make use of new functionalities and fixes as they become available

See: https://docs.docker.com/build/dockerfile/frontend/#stable-channel

Also use `set -e` on `RUN`'s heredoc syntax to avoid a build to succeed even when a build stage fails.