### PR TITLE
Feature/isolate emulator tools step

### DIFF
--- a/cpp-low-level/Dockerfile
+++ b/cpp-low-level/Dockerfile
@@ -4,7 +4,7 @@ FROM --platform=linux/riscv64 riscv64/ubuntu:22.04 as builder
 RUN <<EOF
 set -e
 apt-get update
-apt-get install -y --no-install-recommends autoconf automake ca-certificates curl build-essential libtool wget 
+apt-get install -y --no-install-recommends autoconf automake ca-certificates curl build-essential libtool wget
 rm -rf /var/lib/apt/lists/*
 EOF
 
@@ -17,7 +17,8 @@ FROM --platform=linux/riscv64 riscv64/ubuntu:22.04
 
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb /
-RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
+RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
+  && rm /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
 
 LABEL io.sunodo.sdk_version=0.2.0
 LABEL io.cartesi.rollups.ram_size=128Mi

--- a/cpp-low-level/Dockerfile
+++ b/cpp-low-level/Dockerfile
@@ -15,16 +15,18 @@ RUN make
 
 FROM --platform=linux/riscv64 riscv64/ubuntu:22.04
 
+ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
+ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb /
+RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
+
 LABEL io.sunodo.sdk_version=0.2.0
 LABEL io.cartesi.rollups.ram_size=128Mi
 
-ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
 set -e
 apt-get update
-apt-get install -y --no-install-recommends busybox-static=1:1.30.1-7ubuntu3 ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.15
-curl -fsSL https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.tar.gz \
-  | tar -C / --overwrite -xvzf -
+apt-get install -y --no-install-recommends \
+  busybox-static=1:1.30.1-7ubuntu3
 rm -rf /var/lib/apt/lists/*
 EOF
 

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -16,7 +16,8 @@ FROM --platform=linux/riscv64 riscv64/ubuntu:22.04
 
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb /
-RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
+RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
+  && rm /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
 
 LABEL io.sunodo.sdk_version=0.2.0
 LABEL io.cartesi.rollups.ram_size=128Mi

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -14,17 +14,18 @@ RUN make
 
 FROM --platform=linux/riscv64 riscv64/ubuntu:22.04
 
+ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
+ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb /
+RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
+
 LABEL io.sunodo.sdk_version=0.2.0
 LABEL io.cartesi.rollups.ram_size=128Mi
 
-ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
 set -e
 apt-get update
-apt-get install -y --no-install-recommends busybox-static=1:1.30.1-7ubuntu3 ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.15
-cd /tmp
-curl -fsSL https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.tar.gz \
-  | tar -C / --overwrite -xvzf -
+apt-get install -y --no-install-recommends \
+  busybox-static=1:1.30.1-7ubuntu3
 rm -rf /var/lib/apt/lists/*
 EOF
 

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -33,7 +33,8 @@ FROM --platform=linux/riscv64 riscv64/ubuntu:22.04
 
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb /
-RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
+RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
+  && rm /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
 
 LABEL io.sunodo.sdk_version=0.2.0
 LABEL io.cartesi.rollups.ram_size=128Mi

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -31,16 +31,18 @@ RUN make
 # runtime stage: produces final image that will be executed
 FROM --platform=linux/riscv64 riscv64/ubuntu:22.04
 
+ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
+ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb /
+RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
+
 LABEL io.sunodo.sdk_version=0.2.0
 LABEL io.cartesi.rollups.ram_size=128Mi
 
-ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
 set -e
 apt-get update
-apt-get install -y --no-install-recommends busybox-static=1:1.30.1-7ubuntu3 ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.15
-curl -fsSL https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.tar.gz \
-  | tar -C / --overwrite -xvzf -
+apt-get install -y --no-install-recommends \
+  busybox-static=1:1.30.1-7ubuntu3
 rm -rf /var/lib/apt/lists/*
 EOF
 

--- a/javascript/Dockerfile
+++ b/javascript/Dockerfile
@@ -21,7 +21,8 @@ FROM --platform=linux/riscv64 cartesi/node:20.8.0-jammy-slim
 
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb /
-RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
+RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
+  && rm /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
 
 LABEL io.sunodo.sdk_version=0.2.0
 LABEL io.cartesi.rollups.ram_size=128Mi

--- a/javascript/Dockerfile
+++ b/javascript/Dockerfile
@@ -19,16 +19,18 @@ RUN yarn install && yarn build
 # performance when loading the Cartesi Machine.
 FROM --platform=linux/riscv64 cartesi/node:20.8.0-jammy-slim
 
+ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
+ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb /
+RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
+
 LABEL io.sunodo.sdk_version=0.2.0
 LABEL io.cartesi.rollups.ram_size=128Mi
 
-ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
 set -e
 apt-get update
-apt-get install -y --no-install-recommends busybox-static=1:1.30.1-7ubuntu3 ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.15
-curl -fsSL https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.tar.gz \
-  | tar -C / --overwrite -xvzf -
+apt-get install -y --no-install-recommends \
+  busybox-static=1:1.30.1-7ubuntu3
 rm -rf /var/lib/apt/lists/*
 EOF
 

--- a/lua/Dockerfile
+++ b/lua/Dockerfile
@@ -15,7 +15,8 @@ FROM --platform=linux/riscv64 riscv64/ubuntu:22.04
 
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb /
-RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
+RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
+  && rm /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
 
 LABEL io.sunodo.sdk_version=0.2.0
 LABEL io.cartesi.rollups.ram_size=128Mi

--- a/lua/Dockerfile
+++ b/lua/Dockerfile
@@ -13,21 +13,20 @@ EOF
 
 FROM --platform=linux/riscv64 riscv64/ubuntu:22.04
 
+ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
+ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb /
+RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
+
 LABEL io.sunodo.sdk_version=0.2.0
 LABEL io.cartesi.rollups.ram_size=128Mi
 
-ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
 set -e
 apt-get update
 apt-get install -y --no-install-recommends \
   busybox-static=1:1.30.1-7ubuntu3 \
-  ca-certificates=20230311ubuntu0.22.04.1 \
-  curl=7.81.0-1ubuntu1.15 \
   liblua5.4-dev=5.4.4-1 \
   lua5.4=5.4.4-1
-curl -fsSL https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.tar.gz \
-  | tar -C / --overwrite -xvzf -
 rm -rf /var/lib/apt/lists/*
 EOF
 

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,16 +1,18 @@
 # syntax=docker.io/docker/dockerfile:1
 FROM --platform=linux/riscv64 cartesi/python:3.10-slim-jammy
 
+ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
+ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb /
+RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
+
 LABEL io.sunodo.sdk_version=0.2.0
 LABEL io.cartesi.rollups.ram_size=128Mi
 
-ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
 set -e
 apt-get update
-apt-get install -y --no-install-recommends busybox-static=1:1.30.1-7ubuntu3 ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.15
-curl -fsSL https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.tar.gz \
-  | tar -C / --overwrite -xvzf -
+apt-get install -y --no-install-recommends \
+  busybox-static=1:1.30.1-7ubuntu3
 rm -rf /var/lib/apt/lists/*
 EOF
 

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -3,7 +3,8 @@ FROM --platform=linux/riscv64 cartesi/python:3.10-slim-jammy
 
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb /
-RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
+RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
+  && rm /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
 
 LABEL io.sunodo.sdk_version=0.2.0
 LABEL io.cartesi.rollups.ram_size=128Mi

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -22,16 +22,19 @@ EOF
 
 FROM base
 
+ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
+ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb /
+RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
+
 LABEL io.sunodo.sdk_version=0.2.0
 LABEL io.cartesi.rollups.ram_size=128Mi
 
-ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
 set -e
 apt-get update
-apt-get install -y --no-install-recommends busybox-static=1:1.30.1-7ubuntu3 ruby="1:3.0~exp1" ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.15
-curl -fsSL https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.tar.gz \
-  | tar -C / --overwrite -xvzf -
+apt-get install -y --no-install-recommends \
+  busybox-static=1:1.30.1-7ubuntu3 \
+  ruby="1:3.0~exp1"
 rm -rf /var/lib/apt/lists/*
 EOF
 

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -24,7 +24,8 @@ FROM base
 
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb /
-RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
+RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
+  && rm /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
 
 LABEL io.sunodo.sdk_version=0.2.0
 LABEL io.cartesi.rollups.ram_size=128Mi

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -44,20 +44,18 @@ RUN cargo build --release
 
 FROM --platform=linux/riscv64 riscv64/ubuntu:22.04
 
+ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
+ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb /
+RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
+
 LABEL io.sunodo.sdk_version=0.2.0
 LABEL io.cartesi.rollups.ram_size=128Mi
-
-ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 
 RUN <<EOF
 set -e
 apt-get update
 apt-get install -y --no-install-recommends \
-    busybox-static=1:1.30.1-7ubuntu3 \
-    ca-certificates=20230311ubuntu0.22.04.1 \
-    curl=7.81.0-1ubuntu1.15
-curl -fsSL https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.tar.gz \
-  | tar -C / --overwrite -xvzf -
+    busybox-static=1:1.30.1-7ubuntu3
 rm -rf /var/lib/apt/lists/*
 EOF
 

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -46,7 +46,8 @@ FROM --platform=linux/riscv64 riscv64/ubuntu:22.04
 
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb /
-RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
+RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
+    && rm /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
 
 LABEL io.sunodo.sdk_version=0.2.0
 LABEL io.cartesi.rollups.ram_size=128Mi

--- a/typescript/Dockerfile
+++ b/typescript/Dockerfile
@@ -21,7 +21,8 @@ FROM --platform=linux/riscv64 cartesi/node:20.8.0-jammy-slim
 
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb /
-RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
+RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
+  && rm /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
 
 LABEL io.sunodo.sdk_version=0.2.0
 LABEL io.cartesi.rollups.ram_size=128Mi

--- a/typescript/Dockerfile
+++ b/typescript/Dockerfile
@@ -19,16 +19,18 @@ RUN yarn install && yarn build
 # performance when loading the Cartesi Machine.
 FROM --platform=linux/riscv64 cartesi/node:20.8.0-jammy-slim
 
+ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
+ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb /
+RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
+
 LABEL io.sunodo.sdk_version=0.2.0
 LABEL io.cartesi.rollups.ram_size=128Mi
 
-ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
 set -e
 apt-get update
-apt-get install -y --no-install-recommends busybox-static=1:1.30.1-7ubuntu3 ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.15
-curl -fsSL https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.tar.gz \
-  | tar -C / --overwrite -xvzf -
+apt-get install -y --no-install-recommends \
+  busybox-static=1:1.30.1-7ubuntu3
 rm -rf /var/lib/apt/lists/*
 EOF
 


### PR DESCRIPTION
This PR will isolate the Dockerfile layer where the machine-emulator-tools is installed, so that users won't easily mess with this specific RUN instruction.

~And also has a little refactor for the apt packages being installed, one new line for each and sorted.~

Since we install machine-emulator-tools.deb using `ADD` and `RUN`, we don't need `curl` nor `ca-certificates` on the final image.