### PR TITLE
feat: move LABEL to EOF for better caching

### DIFF
--- a/cpp-low-level/Dockerfile
+++ b/cpp-low-level/Dockerfile
@@ -15,9 +15,6 @@ RUN make
 
 FROM --platform=linux/riscv64 riscv64/ubuntu:22.04
 
-LABEL io.sunodo.sdk_version=0.2.0
-LABEL io.cartesi.rollups.ram_size=128Mi
-
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
 set -e
@@ -34,3 +31,6 @@ WORKDIR /opt/cartesi/dapp
 COPY --from=builder /opt/cartesi/dapp/dapp .
 
 ENTRYPOINT ["/opt/cartesi/dapp/dapp"]
+
+LABEL io.sunodo.sdk_version=0.2.0
+LABEL io.cartesi.rollups.ram_size=128Mi

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -14,9 +14,6 @@ RUN make
 
 FROM --platform=linux/riscv64 riscv64/ubuntu:22.04
 
-LABEL io.sunodo.sdk_version=0.2.0
-LABEL io.cartesi.rollups.ram_size=128Mi
-
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
 set -e
@@ -37,3 +34,6 @@ ENV ROLLUP_HTTP_SERVER_URL="http://127.0.0.1:5004"
 
 ENTRYPOINT ["rollup-init"]
 CMD ["/opt/cartesi/dapp/dapp"]
+
+LABEL io.sunodo.sdk_version=0.2.0
+LABEL io.cartesi.rollups.ram_size=128Mi

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -31,9 +31,6 @@ RUN make
 # runtime stage: produces final image that will be executed
 FROM --platform=linux/riscv64 riscv64/ubuntu:22.04
 
-LABEL io.sunodo.sdk_version=0.2.0
-LABEL io.cartesi.rollups.ram_size=128Mi
-
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
 set -e
@@ -53,3 +50,6 @@ ENV ROLLUP_HTTP_SERVER_URL="http://127.0.0.1:5004"
 
 ENTRYPOINT ["rollup-init"]
 CMD ["/opt/cartesi/dapp/dapp"]
+
+LABEL io.sunodo.sdk_version=0.2.0
+LABEL io.cartesi.rollups.ram_size=128Mi

--- a/javascript/Dockerfile
+++ b/javascript/Dockerfile
@@ -19,9 +19,6 @@ RUN yarn install && yarn build
 # performance when loading the Cartesi Machine.
 FROM --platform=linux/riscv64 cartesi/node:20.8.0-jammy-slim
 
-LABEL io.sunodo.sdk_version=0.2.0
-LABEL io.cartesi.rollups.ram_size=128Mi
-
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
 set -e
@@ -41,3 +38,6 @@ ENV ROLLUP_HTTP_SERVER_URL="http://127.0.0.1:5004"
 
 ENTRYPOINT ["rollup-init"]
 CMD ["node", "index.js"]
+
+LABEL io.sunodo.sdk_version=0.2.0
+LABEL io.cartesi.rollups.ram_size=128Mi

--- a/lua/Dockerfile
+++ b/lua/Dockerfile
@@ -13,9 +13,6 @@ EOF
 
 FROM --platform=linux/riscv64 riscv64/ubuntu:22.04
 
-LABEL io.sunodo.sdk_version=0.2.0
-LABEL io.cartesi.rollups.ram_size=128Mi
-
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
 set -e
@@ -43,3 +40,6 @@ ENV ROLLUP_HTTP_SERVER_URL="http://127.0.0.1:5004"
 
 ENTRYPOINT ["rollup-init"]
 CMD ["lua", "dapp.lua"]
+
+LABEL io.sunodo.sdk_version=0.2.0
+LABEL io.cartesi.rollups.ram_size=128Mi

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,9 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1
 FROM --platform=linux/riscv64 cartesi/python:3.10-slim-jammy
 
-LABEL io.sunodo.sdk_version=0.2.0
-LABEL io.cartesi.rollups.ram_size=128Mi
-
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
 set -e
@@ -31,3 +28,6 @@ ENV ROLLUP_HTTP_SERVER_URL="http://127.0.0.1:5004"
 
 ENTRYPOINT ["rollup-init"]
 CMD ["python3", "dapp.py"]
+
+LABEL io.sunodo.sdk_version=0.2.0
+LABEL io.cartesi.rollups.ram_size=128Mi

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -22,9 +22,6 @@ EOF
 
 FROM base
 
-LABEL io.sunodo.sdk_version=0.2.0
-LABEL io.cartesi.rollups.ram_size=128Mi
-
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
 set -e
@@ -45,3 +42,6 @@ COPY . .
 
 ENTRYPOINT ["rollup-init"]
 CMD ["ruby", "main.rb"]
+
+LABEL io.sunodo.sdk_version=0.2.0
+LABEL io.cartesi.rollups.ram_size=128Mi

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -44,9 +44,6 @@ RUN cargo build --release
 
 FROM --platform=linux/riscv64 riscv64/ubuntu:22.04
 
-LABEL io.sunodo.sdk_version=0.2.0
-LABEL io.cartesi.rollups.ram_size=128Mi
-
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 
 RUN <<EOF
@@ -70,3 +67,6 @@ ENV ROLLUP_HTTP_SERVER_URL="http://127.0.0.1:5004"
 
 ENTRYPOINT ["rollup-init"]
 CMD ["dapp"]
+
+LABEL io.sunodo.sdk_version=0.2.0
+LABEL io.cartesi.rollups.ram_size=128Mi

--- a/typescript/Dockerfile
+++ b/typescript/Dockerfile
@@ -19,9 +19,6 @@ RUN yarn install && yarn build
 # performance when loading the Cartesi Machine.
 FROM --platform=linux/riscv64 cartesi/node:20.8.0-jammy-slim
 
-LABEL io.sunodo.sdk_version=0.2.0
-LABEL io.cartesi.rollups.ram_size=128Mi
-
 ARG MACHINE_EMULATOR_TOOLS_VERSION=0.12.0
 RUN <<EOF
 set -e
@@ -41,3 +38,6 @@ ENV ROLLUP_HTTP_SERVER_URL="http://127.0.0.1:5004"
 
 ENTRYPOINT ["rollup-init"]
 CMD ["node", "index.js"]
+
+LABEL io.sunodo.sdk_version=0.2.0
+LABEL io.cartesi.rollups.ram_size=128Mi


### PR DESCRIPTION
This PR pouts the LABEL at the end of file, so that when changing the LABEL it won't affect the docker cache and make it run the following steps again.