### PR TITLE
Update emulator sdk

### DIFF
--- a/cpp-low-level/Dockerfile
+++ b/cpp-low-level/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker.io/docker/dockerfile:1
 FROM --platform=linux/riscv64 riscv64/ubuntu:22.04 as builder
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get update
@@ -30,6 +31,7 @@ RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
 LABEL io.sunodo.sdk_version=0.2.0
 LABEL io.cartesi.rollups.ram_size=128Mi
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get update

--- a/cpp-low-level/Dockerfile
+++ b/cpp-low-level/Dockerfile
@@ -16,7 +16,7 @@ apt-get install -y --no-install-recommends \
 rm -rf /var/lib/apt/lists/*
 EOF
 
-COPY --from=sunodo/sdk:0.2.0 /opt/riscv /opt/riscv
+COPY --from=sunodo/sdk:0.3.0 /opt/riscv /opt/riscv
 WORKDIR /opt/cartesi/dapp
 COPY . .
 RUN make
@@ -28,7 +28,7 @@ ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHI
 RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
   && rm /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
 
-LABEL io.sunodo.sdk_version=0.2.0
+LABEL io.sunodo.sdk_version=0.3.0
 LABEL io.cartesi.rollups.ram_size=128Mi
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/cpp-low-level/Dockerfile
+++ b/cpp-low-level/Dockerfile
@@ -4,7 +4,14 @@ FROM --platform=linux/riscv64 riscv64/ubuntu:22.04 as builder
 RUN <<EOF
 set -e
 apt-get update
-apt-get install -y --no-install-recommends autoconf automake ca-certificates curl build-essential libtool wget
+apt-get install -y --no-install-recommends \
+  autoconf \
+  automake \
+  build-essential \
+  ca-certificates \
+  curl \
+  libtool \
+  wget 
 rm -rf /var/lib/apt/lists/*
 EOF
 

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -27,7 +27,7 @@ ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHI
 RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
   && rm /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
 
-LABEL io.sunodo.sdk_version=0.2.0
+LABEL io.sunodo.sdk_version=0.3.0
 LABEL io.cartesi.rollups.ram_size=128Mi
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -4,7 +4,14 @@ FROM --platform=linux/riscv64 riscv64/ubuntu:22.04 as builder
 RUN <<EOF
 set -e
 apt-get update
-apt-get install -y --no-install-recommends autoconf automake ca-certificates curl build-essential libtool wget
+apt-get install -y --no-install-recommends \
+  autoconf \
+  automake \
+  build-essential \
+  ca-certificates \
+  curl \
+  libtool \
+  wget
 rm -rf /var/lib/apt/lists/*
 EOF
 

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker.io/docker/dockerfile:1
 FROM --platform=linux/riscv64 riscv64/ubuntu:22.04 as builder
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get update
@@ -29,6 +30,7 @@ RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
 LABEL io.sunodo.sdk_version=0.2.0
 LABEL io.cartesi.rollups.ram_size=128Mi
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get update

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -37,7 +37,7 @@ ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHI
 RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
   && rm /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
 
-LABEL io.sunodo.sdk_version=0.2.0
+LABEL io.sunodo.sdk_version=0.3.0
 LABEL io.cartesi.rollups.ram_size=128Mi
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker.io/docker/dockerfile:1
 FROM ubuntu:22.04 as build-stage
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt update
@@ -39,6 +40,7 @@ RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
 LABEL io.sunodo.sdk_version=0.2.0
 LABEL io.cartesi.rollups.ram_size=128Mi
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get update

--- a/javascript/Dockerfile
+++ b/javascript/Dockerfile
@@ -27,6 +27,7 @@ RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
 LABEL io.sunodo.sdk_version=0.2.0
 LABEL io.cartesi.rollups.ram_size=128Mi
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get update

--- a/javascript/Dockerfile
+++ b/javascript/Dockerfile
@@ -24,7 +24,7 @@ ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHI
 RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
   && rm /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
 
-LABEL io.sunodo.sdk_version=0.2.0
+LABEL io.sunodo.sdk_version=0.3.0
 LABEL io.cartesi.rollups.ram_size=128Mi
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/lua/Dockerfile
+++ b/lua/Dockerfile
@@ -4,7 +4,11 @@ FROM --platform=linux/riscv64 riscv64/ubuntu:22.04 as builder
 RUN <<EOF
 set -e
 apt-get update
-apt-get install -y --no-install-recommends build-essential=12.9ubuntu3 lua5.4=5.4.4-1 liblua5.4-dev=5.4.4-1 luarocks=3.8.0+dfsg1-1
+apt-get install -y --no-install-recommends \
+  build-essential=12.9ubuntu3 \
+  lua5.4=5.4.4-1 \
+  liblua5.4-dev=5.4.4-1 \
+  luarocks=3.8.0+dfsg1-1
 rm -rf /var/lib/apt/lists/*
 
 luarocks install --lua-version=5.4 luasocket 3.1.0-1

--- a/lua/Dockerfile
+++ b/lua/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker.io/docker/dockerfile:1
 FROM --platform=linux/riscv64 riscv64/ubuntu:22.04 as builder
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get update
@@ -25,6 +26,7 @@ RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
 LABEL io.sunodo.sdk_version=0.2.0
 LABEL io.cartesi.rollups.ram_size=128Mi
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get update

--- a/lua/Dockerfile
+++ b/lua/Dockerfile
@@ -23,7 +23,7 @@ ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHI
 RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
   && rm /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
 
-LABEL io.sunodo.sdk_version=0.2.0
+LABEL io.sunodo.sdk_version=0.3.0
 LABEL io.cartesi.rollups.ram_size=128Mi
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -6,7 +6,7 @@ ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHI
 RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
   && rm /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
 
-LABEL io.sunodo.sdk_version=0.2.0
+LABEL io.sunodo.sdk_version=0.3.0
 LABEL io.cartesi.rollups.ram_size=128Mi
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -9,6 +9,7 @@ RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
 LABEL io.sunodo.sdk_version=0.2.0
 LABEL io.cartesi.rollups.ram_size=128Mi
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get update

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update
 
 FROM base as builder
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get install -y --no-install-recommends \
@@ -33,6 +34,7 @@ RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
 LABEL io.sunodo.sdk_version=0.2.0
 LABEL io.cartesi.rollups.ram_size=128Mi
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get update

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -7,7 +7,10 @@ FROM base as builder
 
 RUN <<EOF
 set -e
-apt-get install -y ruby="1:3.0~exp1" ruby-dev="1:3.0~exp1" build-essential=12.9ubuntu3
+apt-get install -y --no-install-recommends \
+  build-essential=12.9ubuntu3 \
+  ruby-dev="1:3.0~exp1" \
+  ruby="1:3.0~exp1"
 rm -rf /var/apt/lists/*
 gem install bundler --no-document
 EOF

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -31,7 +31,7 @@ ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHI
 RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
   && rm /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
 
-LABEL io.sunodo.sdk_version=0.2.0
+LABEL io.sunodo.sdk_version=0.3.0
 LABEL io.cartesi.rollups.ram_size=128Mi
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -6,6 +6,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     PATH=/usr/local/cargo/bin:$PATH \
     RUST_VERSION=1.72.0
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt update
@@ -52,6 +53,7 @@ RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
 LABEL io.sunodo.sdk_version=0.2.0
 LABEL io.cartesi.rollups.ram_size=128Mi
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get update

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -50,7 +50,7 @@ ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHI
 RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
     && rm /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
 
-LABEL io.sunodo.sdk_version=0.2.0
+LABEL io.sunodo.sdk_version=0.3.0
 LABEL io.cartesi.rollups.ram_size=128Mi
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/typescript/Dockerfile
+++ b/typescript/Dockerfile
@@ -27,6 +27,7 @@ RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
 LABEL io.sunodo.sdk_version=0.2.0
 LABEL io.cartesi.rollups.ram_size=128Mi
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN <<EOF
 set -e
 apt-get update

--- a/typescript/Dockerfile
+++ b/typescript/Dockerfile
@@ -24,7 +24,7 @@ ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHI
 RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
   && rm /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
 
-LABEL io.sunodo.sdk_version=0.2.0
+LABEL io.sunodo.sdk_version=0.3.0
 LABEL io.cartesi.rollups.ram_size=128Mi
 
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
This PR will update to `sunodo/sdk:0.3.0` and some other refactorings.

Need to create a `sdk-0.3` branch when merged to main.

Depends on sunodo/sdk:0.3.0 release. https://github.com/sunodo/sunodo/pull/357
